### PR TITLE
chore(dependabot): Fix dependency update grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,9 @@ updates:
     groups:
       paperback:
         patterns:
-          - "@paperback/*"
+          - "@paperback/toolchain"
+          - "@paperback/types"
+          - "@paperback/runtime-polyfills"
       minor-patch:
         update-types:
           - minor
@@ -18,6 +20,3 @@ updates:
       major:
         update-types:
           - major
-      pre-release:
-        patterns:
-          - "*-*"


### PR DESCRIPTION
# Summary

Fix Dependabot dependency update grouping. Glob pattern matching is broken, so pin each `@paperback` dependency individually and drop the non-functional pre-release group.

## Checklist

### Making changes

- [x] Follows Inkdex's [Contributing Guidelines](https://github.com/inkdex/extensions/blob/master/.github/CONTRIBUTING.md).

#### For updates to existing extensions

- [ ] Updated `pbConfig.version` for extension specific changes or `BASE_VERSION` for generic wide changes.

> N/A — CI/config-only change to `.github/dependabot.yml`; no extension code or built output is affected.

#### For new extensions

- [ ] Generated tests with `npx paperback-cli test --generate EXTENSION_NAME`.

### Testing changes

- [ ] `npm run conformance` passes.
- [ ] `npm test -- EXTENSION_NAME` passes.
- [ ] Bundled the extension and verified it works in the Paperback app.

> N/A — Dependabot configuration change only.

### Committing changes

- [x] Commit messages follow the existing convention (`type(Scope): summary`, e.g. `fix(EXTENSION_NAME): ...`).

### AI assistance

Pick one:

- [x] This PR contains no AI-assisted changes.
- [ ] This PR is AI-assisted. I manually reviewed every change and added an `Assisted-by: AGENT_NAME:MODEL_VERSION` trailer to each AI-assisted commit.
