### PR TITLE
fix(MangaNato): fix Cloudflare bypass for MangaNato

### DIFF
--- a/src/MangaNato/main.ts
+++ b/src/MangaNato/main.ts
@@ -13,6 +13,7 @@ class MangaNatoExtension extends Mangabox {
       name: pbconfig.name,
       contentRating: pbconfig.contentRating,
       language: pbconfig.language,
+      bypassPage: `${DOMAIN}/search/story`,
     });
   }
 }

--- a/src/generic/config.ts
+++ b/src/generic/config.ts
@@ -8,7 +8,7 @@ import {
   type SourceDeveloper,
 } from "@paperback/types";
 
-const BASE_VERSION = "1.0.0-alpha.9";
+const BASE_VERSION = "1.0.0-alpha.10";
 
 export const basePbConfig = {
   name: "",
@@ -20,7 +20,6 @@ export const basePbConfig = {
   capabilities: [
     SourceIntents.CHAPTER_PROVIDING,
     SourceIntents.DISCOVER_SECTION_PROVIDING,
-    SourceIntents.SETTINGS_FORM_PROVIDING,
     SourceIntents.SEARCH_RESULT_PROVIDING,
     SourceIntents.CLOUDFLARE_BYPASS_PROVIDING,
   ],

--- a/src/generic/main.ts
+++ b/src/generic/main.ts
@@ -5,22 +5,17 @@ import {
   BasicRateLimiter,
   type Chapter,
   type ChapterDetails,
-  type ChapterProviding,
-  type CloudflareBypassRequestProviding,
   ContentRating,
   type Cookie,
   CookieStorageInterceptor,
   type DiscoverSection,
   type DiscoverSectionItem,
-  type DiscoverSectionProviding,
+  type ExtensionImpl,
   DiscoverSectionType,
-  type Extension,
-  type MangaProviding,
   type PagedResults,
   PaperbackInterceptor,
   type SearchQuery,
   type SearchResultItem,
-  type SearchResultsProviding,
   type SourceManga,
   type TagSection,
   URL,
@@ -32,6 +27,7 @@ import {
 } from "@paperback/types/lib/compat/0.8";
 import * as cheerio from "cheerio";
 
+import { type basePbConfig } from "./config";
 import { MangaboxInterceptor } from "./network";
 import { MangaboxParser } from "./parsers";
 
@@ -43,6 +39,7 @@ export interface MangaboxParams {
   parser?: MangaboxParser;
   requestManager?: PaperbackInterceptor;
   rateLimiter?: BasicRateLimiter;
+  bypassPage?: string;
 }
 
 type Metadata = {
@@ -50,12 +47,7 @@ type Metadata = {
   completed?: boolean;
 };
 
-type MangaboxImplementation = Extension &
-  DiscoverSectionProviding &
-  SearchResultsProviding &
-  MangaProviding &
-  ChapterProviding &
-  CloudflareBypassRequestProviding;
+type MangaboxImplementation = ExtensionImpl<typeof basePbConfig>;
 
 export abstract class Mangabox implements MangaboxImplementation {
   /**
@@ -92,7 +84,7 @@ export abstract class Mangabox implements MangaboxImplementation {
     this.defaultContentRating = params.contentRating ?? ContentRating.EVERYONE;
     this.language = params.language ?? "🇬🇧";
     this.parser = params.parser ?? new MangaboxParser();
-    this.bypassPage = `${this.domain}/manga`;
+    this.bypassPage = params.bypassPage ?? `${this.domain}/manga`;
     this.requestManager = params.requestManager ?? new MangaboxInterceptor("main", this);
     this.rateLimiter =
       params.rateLimiter ??


### PR DESCRIPTION
fix(generic): no settings needed
chore(generic): Derive capabilities from config

# Summary

- fixes Cloudflare bypass for MangaNato
- derives capabilities from config
- removes unused settings SourceIntent

## Checklist

### Making changes

- [x] Follows Inkdex's [Contributing Guidelines](https://github.com/inkdex/extensions/blob/master/.github/CONTRIBUTING.md).

#### For updates to existing extensions

- [x] Updated `pbConfig.version` for extension specific changes or `BASE_VERSION` for generic wide changes.

#### For new extensions

- [ ] Generated tests with `npx paperback-cli test --generate EXTENSION_NAME`.

### Testing changes

- [x] `npm run conformance` passes.
- [x] `npm test -- EXTENSION_NAME` passes.
- [x] Bundled the extension and verified it works in the Paperback app.

### Committing changes

- [x] Commit messages follow the existing convention (`type(Scope): summary`, e.g. `fix(EXTENSION_NAME): ...`).

### AI assistance

Pick one:

- [x] This PR contains no AI-assisted changes.
- [ ] This PR is AI-assisted. I manually reviewed every change and added an `Assisted-by: AGENT_NAME:MODEL_VERSION` trailer to each AI-assisted commit.
