### PR TITLE
fix(generic): increase bufferInterval

### DIFF
--- a/src/generic/config.ts
+++ b/src/generic/config.ts
@@ -8,7 +8,7 @@ import {
   type SourceDeveloper,
 } from "@paperback/types";
 
-const BASE_VERSION = "1.0.0-alpha.10";
+const BASE_VERSION = "1.0.0-alpha.11";
 
 export const basePbConfig = {
   name: "",

--- a/src/generic/main.ts
+++ b/src/generic/main.ts
@@ -89,8 +89,8 @@ export abstract class Mangabox implements MangaboxImplementation {
     this.rateLimiter =
       params.rateLimiter ??
       new BasicRateLimiter("ratelimiter", {
-        numberOfRequests: 5,
-        bufferInterval: 2,
+        numberOfRequests: 2,
+        bufferInterval: 8,
         ignoreImages: true,
       });
   }


### PR DESCRIPTION
I couldn't figure out how to contribute to #58 directly, so I opened a new PR.

- was still easily able to hit 429 with buffer interval at 2. tried a few and i think this is as fast as you can go without any issue
- version bump

# Summary

<!-- What changed and why. 1-3 sentences. -->

## Checklist

### Making changes

- [x] Follows Inkdex's [Contributing Guidelines](https://github.com/inkdex/extensions/blob/master/.github/CONTRIBUTING.md).

#### For updates to existing extensions

- [x] Updated `pbConfig.version` for extension specific changes or `BASE_VERSION` for generic wide changes.

#### For new extensions

- [ ] Generated tests with `npx paperback-cli test --generate EXTENSION_NAME`.

### Testing changes

- [x] `npm run conformance` passes.
- [ ] `npm test -- EXTENSION_NAME` passes.
- [x] Bundled the extension and verified it works in the Paperback app.

### Committing changes

- [x] Commit messages follow the existing convention (`type(Scope): summary`, e.g. `fix(EXTENSION_NAME): ...`).

### AI assistance

Pick one:

- [x] This PR contains no AI-assisted changes.
- [ ] This PR is AI-assisted. I manually reviewed every change and added an `Assisted-by: AGENT_NAME:MODEL_VERSION` trailer to each AI-assisted commit.
